### PR TITLE
Video fixes

### DIFF
--- a/packages/core/src/util/drawer.rs
+++ b/packages/core/src/util/drawer.rs
@@ -9,6 +9,10 @@ pub struct Entity {
 }
 
 pub fn draw_entity(entity: Entity, dimensions: (usize, usize), buf: &mut Vec<Color>) {
+    draw_entity_with_transparency(entity, dimensions, buf, false);
+}
+
+pub fn draw_entity_with_transparency(entity: Entity, dimensions: (usize, usize), buf: &mut Vec<Color>, transparency: bool) {
     for entity_y in 0..entity.height {
         let y = entity_y + entity.y;
         if y >= dimensions.1 {
@@ -19,7 +23,10 @@ pub fn draw_entity(entity: Entity, dimensions: (usize, usize), buf: &mut Vec<Col
         for x in 0..entity.width {
             let buf_idx = base_idx + entity.x + x;
             let entity_idx = entity_base_idx + x;
-            buf[buf_idx] = entity.data[entity_idx];
+            let color = entity.data[entity_idx];
+            if !transparency || color != Color::White {
+                buf[buf_idx] = entity.data[entity_idx];
+            }
         }
     }
 }

--- a/packages/core/src/util/drawer.rs
+++ b/packages/core/src/util/drawer.rs
@@ -11,6 +11,9 @@ pub struct Entity {
 pub fn draw_entity(entity: Entity, dimensions: (usize, usize), buf: &mut Vec<Color>) {
     for entity_y in 0..entity.height {
         let y = entity_y + entity.y;
+        if y >= dimensions.1 {
+            continue;
+        }
         let base_idx = y * dimensions.0;
         let entity_base_idx = entity_y * entity.width;
         for x in 0..entity.width {

--- a/packages/core/src/util/mod.rs
+++ b/packages/core/src/util/mod.rs
@@ -15,7 +15,7 @@ pub fn as_millis(duration: Duration) -> f64 {
     duration.as_secs() as f64 + duration.subsec_nanos() as f64 / 1_000_000_000.0
 }
 
-pub fn wrap_value(value: u8, max: u8) -> u8 {
+pub fn wrap_value(value: usize, max: usize) -> usize {
     if value >= max {
         value - max
     } else {

--- a/packages/core/src/video/control_register.rs
+++ b/packages/core/src/video/control_register.rs
@@ -65,6 +65,7 @@ impl Register for ControlRegister {
     }
 }
 
+#[derive(PartialEq)]
 pub enum TileDataAddressing {
     Mode8000,
     Mode8800,

--- a/packages/core/src/video/memory/background_tile_map.rs
+++ b/packages/core/src/video/memory/background_tile_map.rs
@@ -1,3 +1,5 @@
+use crate::video::control_register::TileDataAddressing;
+
 pub struct BackgroundTileMap {
     tiles: [[u8; 32]; 32],
 }
@@ -9,8 +11,19 @@ impl BackgroundTileMap {
         }
     }
 
-    pub fn tiles(&self) -> Vec<u8> {
-        self.tiles.iter().flat_map(|row| row).cloned().collect()
+    pub fn adjusted_tiles(&self, addressing_mode: TileDataAddressing) -> Vec<u16> {
+        self.tiles
+            .iter()
+            .flat_map(|row| row)
+            .cloned()
+            .map(|tile_index| {
+                if addressing_mode == TileDataAddressing::Mode8800 && tile_index < 128 {
+                    tile_index as u16 + 256
+                } else {
+                    tile_index as u16
+                }
+            })
+            .collect()
     }
 
     fn tile_info_at(&self, address: u16) -> (usize, usize) {

--- a/packages/core/src/video/mod.rs
+++ b/packages/core/src/video/mod.rs
@@ -161,6 +161,10 @@ impl Video {
     fn check_lyc(&self) -> bool {
         self.status.lyc_interrupt_enabled() && self.ly == self.lyc
     }
+
+    pub fn window_visible(&self) -> bool {
+        self.window.0 >= 7 && self.window.0 < 166
+    }
 }
 
 impl Readable for Video {

--- a/packages/core/src/video/screen.rs
+++ b/packages/core/src/video/screen.rs
@@ -66,9 +66,9 @@ impl Screen {
         let (scx, scy) = video.scroll;
         let background_buf = self.background(video);
         for y in 0..self.dimensions.1 {
-            let background_y = wrap_value(scy + y, self.dimensions.1) as usize;
+            let background_y = wrap_value((scy + y) as usize, BACKGROUND_SIZE.1) as usize;
             for x in 0..self.dimensions.0 {
-                let background_x = wrap_value(scx + x, self.dimensions.0) as usize;
+                let background_x = wrap_value((scx + x) as usize, BACKGROUND_SIZE.0) as usize;
                 let idx = y as usize * self.dimensions.0 as usize + x as usize;
                 let background_idx = background_y * BACKGROUND_SIZE.0 + background_x;
                 buffer[idx as usize] = background_buf[background_idx as usize];
@@ -76,7 +76,7 @@ impl Screen {
         }
     }
 
-    fn background(&self, video: &Video) -> Vec<Color> {
+    pub fn background(&self, video: &Video) -> Vec<Color> {
         let background_tile_map = if video.control.bg_map() == 0 {
             &video.vram.background_tile_maps().0
         } else {

--- a/packages/core/src/video/screen.rs
+++ b/packages/core/src/video/screen.rs
@@ -1,5 +1,5 @@
 use crate::util::drawer;
-use crate::util::drawer::Entity;
+use crate::util::drawer::{Entity, draw_entity_with_transparency};
 use crate::util::wrap_value;
 use crate::video::color::Color;
 use crate::video::memory::background_tile_map::BackgroundTileMap;
@@ -58,7 +58,12 @@ impl Screen {
 
         for sprite in sprites.iter() {
             let entity = Entity::from_sprite(sprite);
-            self.draw_entity(entity, buffer);
+            draw_entity_with_transparency(
+                entity,
+                (self.dimensions.0 as usize, self.dimensions.1 as usize),
+                buffer,
+                true
+            )
         }
     }
 
@@ -114,14 +119,6 @@ impl Screen {
             });
 
         background_buf
-    }
-
-    fn draw_entity(&self, entity: Entity, buf: &mut Vec<Color>) {
-        drawer::draw_entity(
-            entity,
-            (self.dimensions.0 as usize, self.dimensions.1 as usize),
-            buf,
-        );
     }
 }
 

--- a/packages/core/src/video/tile.rs
+++ b/packages/core/src/video/tile.rs
@@ -19,10 +19,16 @@ impl Tile {
     }
 
     pub fn colored(&self) -> [Color; 64] {
+        self.colored_with_options(false, false)
+    }
+
+    pub fn colored_with_options(&self, x_flipped: bool, y_flipped: bool) -> [Color; 64] {
         let mut colors: [Color; 64] = [Color::Black; 64];
         for row in 0..8 {
             for col in 0..8 {
-                colors[row * 8 + col] = self.color_at(col as u8, row as u8);
+                let x = if x_flipped { 7 - col } else { col };
+                let y = if y_flipped { 7 - row } else { row };
+                colors[row * 8 + col] = self.color_at(x as u8, y as u8);
             }
         }
         colors

--- a/packages/pc/src/app.rs
+++ b/packages/pc/src/app.rs
@@ -9,6 +9,8 @@ use rustyboy_core::gameboy::{DeviceType, Gameboy};
 use crate::keymap::keymap;
 use crate::shell_debugger::{DebuggerState, ShellDebugger};
 use crate::window::{background::BackgroundWindow, screen::MainWindow, Window};
+use rustyboy_core::cartridge::cartridge_metadata::CartridgeMetadata;
+use std::process::exit;
 
 pub fn run() {
     let matches = App::new("rustyboy")
@@ -16,12 +18,18 @@ pub fn run() {
         .about("Gameboy emulator written in Rust.")
         .args_from_usage(
             "<rom_path> 'ROM path'
-            -d, --debug 'Enable debugger'",
+            -d, --debug 'Enable debugger'
+            -i, --info 'Print cartridge metadata'",
         )
         .get_matches();
 
     let path = matches.value_of("rom_path").unwrap();
     let cartridge = Cartridge::from_file(path).unwrap();
+
+    if matches.is_present("info") {
+        print_cartridge_info(cartridge.metadata());
+        exit(0);
+    }
 
     let debugger = if matches.is_present("debug") {
         Some(Box::new(ShellDebugger::from_state(DebuggerState {
@@ -37,6 +45,23 @@ pub fn run() {
         debugger,
     };
     start_emulation(cartridge, config);
+}
+
+fn print_cartridge_info(metadata: &CartridgeMetadata) {
+    println!("Cartridge metadata");
+    println!("{}", "-".repeat(20));
+
+    println!("Title: {}", metadata.title);
+    println!("Region: {:?}", metadata.destination);
+    println!("Version: {}", metadata.version);
+    println!("GameBoy Color support: {:?}", metadata.cgb_flag);
+    println!("Super GameBoy enhancements: {:?}", metadata.sgb_enhanced);
+    println!("Manufacturer code: {:?}", metadata.manufacturer_code);
+    println!("New licencee code: {:?}", metadata.new_licensee_code);
+    println!("Old licencee code: {:?}", metadata.old_licensee_code);
+    println!("Cartridge capabilities: {:?}", metadata.capabilities);
+    println!("ROM size: {:?}", metadata.rom_size);
+    println!("RAM size: {:?}", metadata.ram_size);
 }
 
 fn start_emulation(cartridge: Cartridge, config: Config) {

--- a/packages/pc/src/app.rs
+++ b/packages/pc/src/app.rs
@@ -8,7 +8,7 @@ use rustyboy_core::gameboy::{DeviceType, Gameboy};
 
 use crate::keymap::keymap;
 use crate::shell_debugger::{DebuggerState, ShellDebugger};
-use crate::window::{screen::MainWindow, Window};
+use crate::window::{background::BackgroundWindow, screen::MainWindow, Window};
 
 pub fn run() {
     let matches = App::new("rustyboy")
@@ -45,12 +45,14 @@ fn start_emulation(cartridge: Cartridge, config: Config) {
     let mut events_loop = EventsLoop::new();
 
     let main_window = MainWindow::new(&events_loop);
+    // let background_window = BackgroundWindow::new(&events_loop);
 
     let mut closed = false;
     while !closed {
         gameboy.run_to_vblank();
 
         main_window.update(&gameboy);
+        // background_window.update(&gameboy);
 
         events_loop.poll_events(|event| match event {
             Event::WindowEvent {

--- a/packages/pc/src/window/background.rs
+++ b/packages/pc/src/window/background.rs
@@ -1,0 +1,44 @@
+use glium::glutin::EventsLoop;
+use glium::texture::RawImage2d;
+use glium::uniforms::MagnifySamplerFilter;
+use glium::{Display, Surface};
+
+use rustyboy_core::gameboy::Gameboy;
+
+use super::{create_display, Window};
+
+pub struct BackgroundWindow {
+    pub display: Display,
+}
+
+impl BackgroundWindow {
+    pub fn new(events_loop: &EventsLoop) -> Self {
+        Self {
+            display: create_display("Rustyboy | Background", &events_loop, (256, 256)),
+        }
+    }
+}
+
+impl Window for BackgroundWindow {
+    fn update(&self, gameboy: &Gameboy) {
+        let mut target = self.display.draw();
+        target.clear_color(0.0, 0.0, 1.0, 1.0);
+
+        let screen = gameboy.hardware().video().screen();
+
+        let buf: Vec<u8> = screen
+            .background(gameboy.hardware().video())
+            .iter()
+            .flat_map(|color| color.to_rgb().to_vec())
+            .collect();
+
+        let img = RawImage2d::from_raw_rgb_reversed(&buf, (256, 256));
+
+        glium::Texture2d::new(&self.display, img)
+            .unwrap()
+            .as_surface()
+            .fill(&target, MagnifySamplerFilter::Nearest);
+
+        target.finish().unwrap();
+    }
+}

--- a/packages/pc/src/window/mod.rs
+++ b/packages/pc/src/window/mod.rs
@@ -4,6 +4,7 @@ use glium::{
 };
 use rustyboy_core::gameboy::Gameboy;
 
+pub mod background;
 pub mod screen;
 
 pub trait Window {


### PR DESCRIPTION
- Fixes a bug by preventing sprites from being drawn outside of the screen
- Fixes the background wrapping behaviour
- Adds a `--info` flag to the PC port that displays cartridge information
- Adds sprites transparency